### PR TITLE
fix: call correct connect method & add generated typings

### DIFF
--- a/packages/simple-tcp-socket/index.ios.ts
+++ b/packages/simple-tcp-socket/index.ios.ts
@@ -3,9 +3,8 @@ import { SimpleTcpSocketCommon } from './common';
 export class SimpleTcpSocket extends SimpleTcpSocketCommon {
   public connect(servername: string, port: number) {
     console.log('connect');
-    // @ts-ignore
     const client = NSCTCPClient.new();
     console.log(client);
-    client.connect(servername, port);
+    client.connectWithServernamePort(servername, port);
   }
 }

--- a/packages/simple-tcp-socket/references.d.ts
+++ b/packages/simple-tcp-socket/references.d.ts
@@ -1,1 +1,10 @@
+/* eslint-disable @typescript-eslint/no-misused-new */
 /// <reference path="../../references.d.ts" />
+
+declare class NSCTCPClient extends NSObject {
+  static alloc(): NSCTCPClient; // inherited from NSObject
+
+  static new(): NSCTCPClient; // inherited from NSObject
+
+  connectWithServernamePort(servername: string, port: number): void;
+}


### PR DESCRIPTION
https://discord.com/channels/603595811204366337/603595811720527881/1039647473565696090

Fixes
```
NativeScript encountered a fatal error: Uncaught TypeError: client.connect is not a function
at connect(file: src/packages/simple-tcp-socket/index.ios.ts:9:11)
```